### PR TITLE
perf(plugin/loader): defer module initialization + fix all failing tests

### DIFF
--- a/lua/gh/commands/issue.lua
+++ b/lua/gh/commands/issue.lua
@@ -200,8 +200,7 @@ end
 ---@param args string[] Command arguments starting after "issue list"
 function M.list(args)
   local repo, filter_opts = parse_list_args(args)
-  local gh = require("gh")
-  gh.issues.open_issue_list(repo, filter_opts)
+  require("gh.issues").open_issue_list(repo, filter_opts)
 end
 
 --- Handle issue view command
@@ -214,16 +213,14 @@ function M.view(args)
     return
   end
 
-  local gh = require("gh")
-  gh.issues.open_issue_detail(number, repo)
+  require("gh.issues").open_issue_detail(number, repo)
 end
 
 --- Handle issue create command
 ---@param args string[] Command arguments starting after "issue create"
 function M.create(args)
   local create_opts = parse_create_args(args)
-  local gh = require("gh")
-  gh.issues.create_issue_buffer(create_opts)
+  require("gh.issues").create_issue_buffer(create_opts)
 end
 
 --- Handle issue close command

--- a/lua/gh/init.lua
+++ b/lua/gh/init.lua
@@ -2,25 +2,34 @@
 --- Provides utilities for working with GitHub CLI in Neovim
 local M = {}
 
-M.cache = require("gh.cache")
-M.cli = require("gh.cli")
-M.issues = require("gh.issues")
-M.buffer = require("gh.ui.buffer")
-M.config = require("gh.config")
+-- Cache for lazy-loaded issues module
+local _issues_cache
 
---- Initialize gh.nvim autocmds
---- This is called automatically on require, no need to call explicitly
-function M.setup()
-  -- Set up buffer registry autocmd for cleanup
-  local registry = require("gh.ui.buffer_registry")
-  registry.setup_autocmd()
-
-  -- Set up autocmds for gh:// buffers
-  M.issues.setup_autocmds()
+--- Get issues module (lazy-loaded)
+---@return table
+local function get_issues()
+  if not _issues_cache then
+    _issues_cache = require("gh.issues")
+  end
+  return _issues_cache
 end
 
--- Auto-setup on require
-M.setup()
+-- Expose issues as a lazy-loaded property
+M.issues = setmetatable({}, {
+  __index = function(_, key)
+    return get_issues()[key]
+  end,
+  __call = function(_, ...)
+    return get_issues()(...)
+  end,
+})
+
+--- Initialize gh.nvim autocmds.
+--- Called once by plugin/gh.lua on the first :Gh command invocation.
+function M.setup()
+  require("gh.ui.buffer_registry").setup_autocmd()
+  get_issues().setup_autocmds()
+end
 
 --- Main entry point for :Gh command
 ---@param opts table Command options from nvim_create_user_command
@@ -32,7 +41,7 @@ function M.command(opts)
   end
 
   -- Pass all args directly to gh CLI
-  M.cli.run(args, function(success, result, error_msg)
+  require("gh.cli").run(args, function(success, result, error_msg)
     if not success then
       vim.notify("gh command failed: " .. (error_msg or "unknown error"), vim.log.levels.ERROR)
       return

--- a/lua/gh/issues/delete.lua
+++ b/lua/gh/issues/delete.lua
@@ -5,6 +5,18 @@ local cli = require("gh.cli")
 local cache = require("gh.cache")
 local config = require("gh.config")
 
+--- Delete issue by number
+---@param number integer Issue number
+---@param repo string|nil Repository (owner/repo)
+---@param callback fun(success: boolean, error: string|nil)
+function M.delete_issue(number, repo, callback)
+  cli.issue.delete(number, repo, function(success, error)
+    if callback then
+      callback(success, error)
+    end
+  end)
+end
+
 --- Delete issue at cursor position
 ---@param bufnr integer Buffer number
 ---@param repo string|nil Repository (owner/repo) or nil for current repo

--- a/lua/gh/issues/init.lua
+++ b/lua/gh/issues/init.lua
@@ -2,39 +2,77 @@
 --- Mirrors gh issue commands
 local M = {}
 
--- Load submodules (mirrors gh issue commands)
-local list = require("gh.issues.list") -- gh issue list
-local view = require("gh.issues.view") -- gh issue view
-local create = require("gh.issues.create") -- gh issue create
-local delete = require("gh.issues.delete") -- gh issue delete
-local close = require("gh.issues.close") -- gh issue close/reopen
+-- Lazy submodule accessors — each submodule is loaded only when first needed
+local function get_list()
+  return require("gh.issues.list")
+end
+local function get_view()
+  return require("gh.issues.view")
+end
+local function get_create()
+  return require("gh.issues.create")
+end
+local function get_delete()
+  return require("gh.issues.delete")
+end
+local function get_close()
+  return require("gh.issues.close")
+end
 
--- Export list functions (gh issue list)
-M.open_issue_list = list.open_issue_list
+-- List (gh issue list)
+function M.open_issue_list(...)
+  return get_list().open_issue_list(...)
+end
 
--- Export view functions (gh issue view)
-M.open_issue_detail = view.open_issue_detail
+-- View (gh issue view)
+function M.open_issue_detail(...)
+  return get_view().open_issue_detail(...)
+end
 
--- Export create functions (gh issue create)
-M.create_issue_buffer = create.create_issue_buffer
-M.get_assignee_completions = create.get_assignee_completions
-M.get_label_completions = create.get_label_completions
-M.get_milestone_completions = create.get_milestone_completions
-M.get_project_completions = create.get_project_completions
-M.get_template_completions = create.get_template_completions
+-- Create (gh issue create)
+function M.create_issue_buffer(...)
+  return get_create().create_issue_buffer(...)
+end
+function M.get_assignee_completions(...)
+  return get_create().get_assignee_completions(...)
+end
+function M.get_label_completions(...)
+  return get_create().get_label_completions(...)
+end
+function M.get_milestone_completions(...)
+  return get_create().get_milestone_completions(...)
+end
+function M.get_project_completions(...)
+  return get_create().get_project_completions(...)
+end
+function M.get_template_completions(...)
+  return get_create().get_template_completions(...)
+end
 
--- Export delete functions (gh issue delete)
-M.delete_issue_at_cursor = delete.delete_issue_at_cursor
+-- Delete (gh issue delete)
+function M.delete_issue_at_cursor(...)
+  return get_delete().delete_issue_at_cursor(...)
+end
 
--- Export close/reopen functions
-M.close_issue = close.close_issue
-M.reopen_issue = close.reopen_issue
-M.get_issue_completions = close.get_issue_completions
+-- Close / reopen (gh issue close / reopen)
+function M.close_issue(...)
+  return get_close().close_issue(...)
+end
+function M.reopen_issue(...)
+  return get_close().reopen_issue(...)
+end
+function M.get_issue_completions(...)
+  return get_close().get_issue_completions(...)
+end
 
--- Setup autocmds
-M.setup_autocmds = list.setup_autocmds
+-- Setup autocmds (called from gh.setup())
+function M.setup_autocmds()
+  get_list().setup_autocmds()
+end
 
 -- Export for testing
-M._test_parse_issue_list_changes = list._test_parse_issue_list_changes
+function M._test_parse_issue_list_changes(...)
+  return get_list()._test_parse_issue_list_changes(...)
+end
 
 return M

--- a/plugin/gh.lua
+++ b/plugin/gh.lua
@@ -1,22 +1,43 @@
 -- TODO: See GitHub issues #25 and #22 — quickfix parsing / gh integration. Add tests and harden gh output handling.
 
--- Check for plenary dependency
-local ok = pcall(require, "plenary.job")
-if not ok then
-  vim.notify("gh.nvim: Plenary not found", vim.log.levels.WARN)
+if vim.g.loaded_gh_nvim then
   return
 end
+vim.g.loaded_gh_nvim = true
 
--- Load gh module
-local gh_module_ok, gh = pcall(require, "gh")
-if not gh_module_ok then
-  vim.notify("gh.nvim: Failed to load gh module: " .. tostring(gh), vim.log.levels.ERROR)
-  return
+local _initialized = false
+
+--- Lazy one-time initialization: checks plenary and sets up autocmds.
+--- Called on first :Gh invocation so nothing runs on Neovim startup.
+---@return boolean success
+local function ensure_initialized()
+  if _initialized then
+    return true
+  end
+
+  if not pcall(require, "plenary.job") then
+    vim.notify("gh.nvim: Plenary not found", vim.log.levels.WARN)
+    return false
+  end
+
+  local ok, err = pcall(function()
+    require("gh").setup()
+  end)
+  if not ok then
+    vim.notify("gh.nvim: Failed to initialize: " .. tostring(err), vim.log.levels.ERROR)
+    return false
+  end
+
+  _initialized = true
+  return true
 end
 
 --- Main gh command handler - mirrors gh CLI structure
---- @param opts table
+---@param opts table
 local function gh_command(opts)
+  if not ensure_initialized() then
+    return
+  end
   local commands = require("gh.commands")
   commands.handle(opts.fargs)
 end

--- a/test/unit/gh/issues/close_spec.lua
+++ b/test/unit/gh/issues/close_spec.lua
@@ -53,18 +53,23 @@ describe("gh.issues.close", function()
   end)
 
   describe("get_issue_completions", function()
-    it("should fetch and cache completions", function(done)
+    it("should fetch and cache completions", function()
       local cache = require("gh.cache")
+      local result = nil
       close.get_issue_completions("owner/repo", "open", function(issues)
-        assert.is_table(issues)
-        assert.equal(1, #issues)
-        assert.equal(1, issues[1].number)
-        
-        -- Check if it was cached
-        local cached = cache.read("issues_completion_owner/repo_open")
-        assert.is_table(cached)
-        done()
+        result = issues
       end)
+
+      vim.wait(500, function()
+        return result ~= nil
+      end)
+
+      assert.is_table(result)
+      assert.equal(1, #result)
+      assert.equal(1, result[1].number)
+
+      local cached = cache.read("issues_completion_owner/repo_open")
+      assert.is_table(cached)
     end)
   end)
 end)

--- a/test/unit/gh/issues/create_spec.lua
+++ b/test/unit/gh/issues/create_spec.lua
@@ -29,9 +29,9 @@ describe("issues.create", function()
   describe("get_label_completions", function()
     it("should fetch and cache labels", function()
       local cli = require("gh.cli")
-      local original_list = cli.list_labels
+      local original_list = cli.label.list
 
-      cli.list_labels = function(repo, callback)
+      cli.label.list = function(opts, callback)
         callback(true, {
           { name = "bug" },
           { name = "enhancement" },
@@ -51,16 +51,16 @@ describe("issues.create", function()
       assert.is_true(vim.tbl_contains(result, "bug"))
       assert.is_true(vim.tbl_contains(result, "enhancement"))
 
-      cli.list_labels = original_list
+      cli.label.list = original_list
     end)
   end)
 
   describe("get_milestone_completions", function()
     it("should fetch and cache milestones", function()
       local cli = require("gh.cli")
-      local original_list = cli.list_milestones
+      local original_list = cli.issue.list_milestones
 
-      cli.list_milestones = function(repo, callback)
+      cli.issue.list_milestones = function(repo, callback)
         callback(true, {
           { title = "v1.0" },
           { title = "v2.0" },
@@ -80,7 +80,7 @@ describe("issues.create", function()
       assert.is_true(vim.tbl_contains(result, "v1.0"))
       assert.is_true(vim.tbl_contains(result, "v2.0"))
 
-      cli.list_milestones = original_list
+      cli.issue.list_milestones = original_list
     end)
   end)
 

--- a/test/unit/gh/issues/delete_spec.lua
+++ b/test/unit/gh/issues/delete_spec.lua
@@ -21,12 +21,18 @@ describe("gh.issues.delete", function()
   end)
 
   describe("delete_issue", function()
-    it("should delete an issue", function(done)
+    it("should delete an issue", function()
+      local result = nil
       delete.delete_issue(1, "owner/repo", function(success, error)
-        assert.is_true(success)
-        assert.is_nil(error)
-        done()
+        result = { success = success, error = error }
       end)
+
+      vim.wait(500, function()
+        return result ~= nil
+      end)
+
+      assert.is_true(result.success)
+      assert.is_nil(result.error)
     end)
   end)
 end)

--- a/test/unit/gh/issues/view_spec.lua
+++ b/test/unit/gh/issues/view_spec.lua
@@ -32,13 +32,12 @@ describe("gh.issues.view", function()
 
   describe("open_issue_detail", function()
     it("should open an issue detail buffer", function()
-      -- Mock nvim API
-      local old_buf_set_lines = vim.api.nvim_buf_set_lines
-      vim.api.nvim_buf_set_lines = function() end
-      
+      local old_metadata = view.add_issue_metadata_virtual_text
+      view.add_issue_metadata_virtual_text = function() end
+
       view.open_issue_detail(1, "owner/repo")
-      
-      vim.api.nvim_buf_set_lines = old_buf_set_lines
+
+      view.add_issue_metadata_virtual_text = old_metadata
     end)
   end)
 end)

--- a/test/unit/gh/ui/buffer_registry_spec.lua
+++ b/test/unit/gh/ui/buffer_registry_spec.lua
@@ -44,11 +44,16 @@ describe("ui.buffer_registry", function()
   end)
 
   it("should unregister by bufnr", function()
+    local original_is_valid = vim.api.nvim_buf_is_valid
+    vim.api.nvim_buf_is_valid = function(buf) return buf == 1 or buf == 2 end
+
     registry.register("test1", 1)
     registry.register("test2", 2)
     registry.unregister_by_bufnr(1)
     assert.is_nil(registry.get("test1"))
     assert.is_not_nil(registry.get("test2"))
+
+    vim.api.nvim_buf_is_valid = original_is_valid
   end)
 
   it("should find by pattern", function()


### PR DESCRIPTION
## Summary

### Lazy loading (startup perf)
- `plugin/gh.lua`: defer plenary check and module initialization to first `:Gh` invocation — zero cost on Neovim startup
- `lua/gh/init.lua`: remove eager submodule requires and auto-setup; expose `issues` via lazy metatable proxy
- `lua/gh/issues/init.lua`: lazy accessor functions — each submodule loaded only when its functions are called
- `lua/gh/commands/issue.lua`: require `gh.issues` directly instead of routing through main module

### Test fixes (6 failures → 0)
- `buffer_registry_spec`: mock `nvim_buf_is_valid` in `unregister_by_bufnr` test
- `delete`: add `delete_issue(number, repo, callback)` function to module; fix `done()` async pattern
- `create_spec`: mock `cli.label.list` / `cli.issue.list_milestones` (actual call sites, not deprecated wrappers)
- `close_spec`: replace unsupported `done()` async pattern with `vim.wait`
- `view_spec`: mock `add_issue_metadata_virtual_text` to avoid out-of-range extmark errors on empty buffer